### PR TITLE
make plugin fail silently

### DIFF
--- a/lib/fluent/plugin/filter_nomad.rb
+++ b/lib/fluent/plugin/filter_nomad.rb
@@ -55,7 +55,7 @@ module Fluent
           @alloc_map_cache = @nomad_client.list_allocations
         rescue Nomad::NomadError => e
           @alloc_map_cache = {}
-          log.error("Nomad client error: #{e}")
+          log.warn("Nomad client error: #{e}")
         end
         initial_cache_entries = @alloc_map_cache.size
         log.info("Nomad client initialized with nomad addr: #{@nomad_addr}, initial cache entries: #{initial_cache_entries}")
@@ -70,7 +70,7 @@ module Fluent
             allocation_map = @nomad_client.list_allocations
           rescue Nomad::NomadError => e
             allocation_map = {}
-            log.error("Nomad client error: #{e}")
+            log.warn("Nomad client error: #{e}")
           end
           @alloc_map_update_queue.push(allocation_map)
         end

--- a/lib/fluent/plugin/filter_nomad.rb
+++ b/lib/fluent/plugin/filter_nomad.rb
@@ -55,7 +55,7 @@ module Fluent
           @alloc_map_cache = @nomad_client.list_allocations
         rescue Nomad::NomadError => e
           @alloc_map_cache = {}
-          log.warn("Nomad client error: #{e}")
+          log.error("Nomad client error: #{e}")
         end
         initial_cache_entries = @alloc_map_cache.size
         log.info("Nomad client initialized with nomad addr: #{@nomad_addr}, initial cache entries: #{initial_cache_entries}")
@@ -70,7 +70,7 @@ module Fluent
             allocation_map = @nomad_client.list_allocations
           rescue Nomad::NomadError => e
             allocation_map = {}
-            log.warn("Nomad client error: #{e}")
+            log.error("Nomad client error: #{e}")
           end
           @alloc_map_update_queue.push(allocation_map)
         end

--- a/lib/nomad/client.rb
+++ b/lib/nomad/client.rb
@@ -143,10 +143,10 @@ module Nomad
         end
       rescue SocketError => e
         @logger.error("NomadConnectError: Could not connect to Nomad server at #{uri.hostname}:#{uri.port}: #{e.message}. Returning empty data.")
-        return []
+        return [] # Return an empty array for consistency
      rescue Timeout::Error => e
         @logger.error("NomadConnectError: Timeout connecting to Nomad server at #{uri.hostname}:#{uri.port}: #{e.message}. Returning empty data.")
-        return []
+        return [] # Return an empty array for consistency
       end
 
       case response
@@ -156,7 +156,7 @@ module Nomad
         @logger.error("NomadClientRequestError: Request to #{uri} failed with status #{response.code} - #{response.message}. Returning empty data.")
         return [] # Return an empty array for consistency
       end
-    rescue JSON::ParserError => e # <--- ADD THIS BLOCK for malformed JSON responses
+    rescue JSON::ParserError => e
         @logger.error("JSONParseError: Failed to parse JSON response from #{uri}: #{e.message}. Returning empty data.")
         return []
     end

--- a/lib/nomad/client.rb
+++ b/lib/nomad/client.rb
@@ -98,7 +98,7 @@ module Nomad
       @nomad_addr = nomad_addr
       @nomad_token = nomad_token
       @logger = Logger.new(STDOUT)
-      @logger.level = Logger::WARN # Log silent errors as warnings
+      @logger.level = Logger::error # Log silent errors as warnings
     end
 
     def list_nodes
@@ -142,10 +142,10 @@ module Nomad
           http.request(request)
         end
       rescue SocketError => e
-        @logger.warn("NomadConnectError: Could not connect to Nomad server at #{uri.hostname}:#{uri.port}: #{e.message}. Returning empty data.")
+        @logger.error("NomadConnectError: Could not connect to Nomad server at #{uri.hostname}:#{uri.port}: #{e.message}. Returning empty data.")
         return []
      rescue Timeout::Error => e
-        @logger.warn("NomadConnectError: Timeout connecting to Nomad server at #{uri.hostname}:#{uri.port}: #{e.message}. Returning empty data.")
+        @logger.error("NomadConnectError: Timeout connecting to Nomad server at #{uri.hostname}:#{uri.port}: #{e.message}. Returning empty data.")
         return []
       end
 
@@ -153,11 +153,11 @@ module Nomad
       when Net::HTTPSuccess
         JSON.parse(response.body)
       else
-        @logger.warn("NomadClientRequestError: Request to #{uri} failed with status #{response.code} - #{response.message}. Returning empty data.")
+        @logger.error("NomadClientRequestError: Request to #{uri} failed with status #{response.code} - #{response.message}. Returning empty data.")
         return [] # Return an empty array for consistency
       end
     rescue JSON::ParserError => e # <--- ADD THIS BLOCK for malformed JSON responses
-        @logger.warn("JSONParseError: Failed to parse JSON response from #{uri}: #{e.message}. Returning empty data.")
+        @logger.error("JSONParseError: Failed to parse JSON response from #{uri}: #{e.message}. Returning empty data.")
         return []
     end
   end

--- a/lib/nomad/client.rb
+++ b/lib/nomad/client.rb
@@ -4,6 +4,7 @@ require 'net/http'
 require 'json'
 require 'socket'
 require 'uri'
+require 'logger'
 
 module Nomad
   def self.if_lookup_ipv4(ifname)
@@ -96,6 +97,8 @@ module Nomad
     def initialize(nomad_addr, nomad_token)
       @nomad_addr = nomad_addr
       @nomad_token = nomad_token
+      @logger = Logger.new(STDOUT)
+      @logger.level = Logger::WARN # Log silent errors as warnings
     end
 
     def list_nodes
@@ -133,20 +136,29 @@ module Nomad
       request = Net::HTTP::Get.new(uri)
       request['X-Nomad-Token'] = @nomad_token
 
+      response = nil
       begin
         response = Net::HTTP.start(uri.hostname, uri.port) do |http|
           http.request(request)
         end
       rescue SocketError => e
-        raise Nomad::NomadConnectError, "Could not connect to Nomad server: #{e.message}"
+        @logger.warn("NomadConnectError: Could not connect to Nomad server at #{uri.hostname}:#{uri.port}: #{e.message}. Returning empty data.")
+        return []
+     rescue Timeout::Error => e
+        @logger.warn("NomadConnectError: Timeout connecting to Nomad server at #{uri.hostname}:#{uri.port}: #{e.message}. Returning empty data.")
+        return []
       end
 
       case response
       when Net::HTTPSuccess
         JSON.parse(response.body)
       else
-        raise Nomad::NomadClientRequestError.new(response.code, response.message)
+        @logger.warn("NomadClientRequestError: Request to #{uri} failed with status #{response.code} - #{response.message}. Returning empty data.")
+        return [] # Return an empty array for consistency
       end
+    rescue JSON::ParserError => e # <--- ADD THIS BLOCK for malformed JSON responses
+        @logger.warn("JSONParseError: Failed to parse JSON response from #{uri}: #{e.message}. Returning empty data.")
+        return []
     end
   end
 end


### PR DESCRIPTION
changing raise to return [] (and adding the Logger for observability), the method now handles the error gracefully without propagating a crash.