### PR TITLE
scrape all namespaces, filter out irrelevant data

### DIFF
--- a/lib/nomad/client.rb
+++ b/lib/nomad/client.rb
@@ -116,16 +116,16 @@ module Nomad
       node&.[]('ID')
     end
 
-    def list_allocations
-      allocations = get_request('/v1/allocations')
+    def list_allocations(namespace: '*')
+      allocations = get_request('/v1/allocations', namespace: namespace)
       allocations.to_h do |alloc|
         summ_alloc = Nomad.summarize_alloc_resp(alloc)
         [summ_alloc[:alloc_id], summ_alloc]
       end
     end
 
-    def get_allocation_info(alloc_id)
-      alloc = get_request("/v1/allocation/#{alloc_id}")
+    def get_allocation_info(alloc_id, namespace: '*')
+      alloc = get_request("/v1/allocation/#{alloc_id}", namespace: namespace)
       if alloc.nil?
         nil
       else
@@ -134,10 +134,11 @@ module Nomad
     end
 
     # Function to make GET requests with headers
-    def get_request(path)
+    def get_request(path, namespace: nil)
       uri = URI("#{@nomad_addr}#{path}")
       request = Net::HTTP::Get.new(uri)
       request['X-Nomad-Token'] = @nomad_token
+      request['X-Nomad-Namespace'] = namespace unless namespace.nil?
 
       begin
         response = Net::HTTP.start(


### PR DESCRIPTION
https://developer.hashicorp.com/nomad/api-docs/allocations#list-allocations

API is only returning default namespace by default

Also it's returning a lot of data we don't need with task states

```
pedro@ams300:~$ curl -H "X-Nomad-Token: fa5c1dc8-f25a-7369-eb99-fc6ea2953570" -H "X-Nomad-Namespace: *" http://ams300.rpcpool.wg:4646/v1/allocations?namespase=alpamayo -s | jq  | wc 
 124854  253704 3832496
pedro@ams300:~$ curl -H "X-Nomad-Token: fa5c1dc8-f25a-7369-eb99-fc6ea2953570" -H "X-Nomad-Namespace: *" "http://ams300.rpcpool.wg:4646/v1/allocations?namespase=alpamayo&task_states=false" -s | jq  | wc  
  18073   35295  543558

```